### PR TITLE
build static lib with -fPic to allow relocation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,7 @@
 
 ./configure \
   --enable-mat73 \
+  --with-pic \
   --enable-extended-sparse \
   --prefix="${PREFIX}" \
   --with-zlib="${PREFIX}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   md5: a79cf9d1200f37e0466062c3ce396d6b
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and (py27 or win32)]
   features:
     - vc9   # [win and py27]


### PR DESCRIPTION
it seems that the libmatio.a shipped on conda forge is not compile with -fPIC so it cannot be linked against a shared object.

I followed what was done here : https://github.com/conda-forge/protobuf-feedstock/pull/26/files which was motivated by https://github.com/conda-forge/protobuf-feedstock/pull/26

cc @massich